### PR TITLE
Fix go formatting issue, fix typo

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -56,11 +56,11 @@ func (e *MarshalerError) Error() string {
 //
 // Examples of struct field tags and their meanings:
 //
-//   // Field appears in INI as key "myName".
-//   Field int `ini:"myName"`
+//	// Field appears in INI as key "myName".
+//	Field int `ini:"myName"`
 //
-//   // Field is ignored by this package.
-//   Field int `ini:"-"`
+//	// Field is ignored by this package.
+//	Field int `ini:"-"`
 //
 // Boolean values encode as the string literal "true" or "false".
 //

--- a/encode.go
+++ b/encode.go
@@ -96,7 +96,7 @@ func Marshal(v interface{}) ([]byte, error) {
 // encode reflects on the values of rv, encoding them as INI data. If rv is not
 // a pointer to a struct, an error is returned. encode makes two passes over
 // the struct fields of rv. The first pass skips struct fields that are
-// themselve structs, encoding all struct fields as "global" INI properties.
+// themselves structs, encoding all struct fields as "global" INI properties.
 // The second pass then encodes each struct field that *is* a struct as an
 // INI section.
 func encode(buf *bytes.Buffer, rv reflect.Value) error {


### PR DESCRIPTION
This PR fixes a typo I spotted in the project.
It also resolves go formatting issues.